### PR TITLE
ci: disable cron scheduler in workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,9 @@
-
 name: Build and Test
 
 on:
   push:
   pull_request:
   repository_dispatch:
-  schedule:
-     - cron: '05 5 1 * *' # <https://crontab.guru/#05_5_1_*_*> - "At 05:05 on day-of-month 1"  
-
 
 jobs:
 


### PR DESCRIPTION
Fixes #4

Disable the cron scheduler in the workflow.

* Remove the `schedule` section from the `on` block in the workflow file `.github/workflows/test.yml`.
